### PR TITLE
Fix incompatibility with tournament (and possibly other mods)

### DIFF
--- a/fabric/src/main/java/io/github/techtastic/cc_vs/fabric/mixin/MixinTileComputer.java
+++ b/fabric/src/main/java/io/github/techtastic/cc_vs/fabric/mixin/MixinTileComputer.java
@@ -31,7 +31,5 @@ public class MixinTileComputer {
         ServerShip ship = VSGameUtilsKt.getShipObjectManagingPos((ServerLevel) level, pos);
 
         CCVSUtils.INSTANCE.applyShipAPIsToComputer(computer, (ServerLevel) level, ship);
-
-        cir.setReturnValue(computer);
     }
 }

--- a/fabric/src/main/java/io/github/techtastic/cc_vs/fabric/mixin/MixinTileTurtle.java
+++ b/fabric/src/main/java/io/github/techtastic/cc_vs/fabric/mixin/MixinTileTurtle.java
@@ -31,7 +31,5 @@ public class MixinTileTurtle {
         ServerShip ship = VSGameUtilsKt.getShipObjectManagingPos((ServerLevel) level, pos);
 
         CCVSUtils.INSTANCE.applyShipAPIsToComputer(computer, (ServerLevel) level, ship);
-
-        cir.setReturnValue(computer);
     }
 }

--- a/forge/src/main/java/io/github/techtastic/cc_vs/forge/mixin/MixinTileComputer.java
+++ b/forge/src/main/java/io/github/techtastic/cc_vs/forge/mixin/MixinTileComputer.java
@@ -30,7 +30,5 @@ public class MixinTileComputer {
         ServerShip ship = VSGameUtilsKt.getShipObjectManagingPos(level, pos);
 
         CCVSUtils.INSTANCE.applyShipAPIsToComputer(computer, level, ship);
-
-        cir.setReturnValue(computer);
     }
 }

--- a/forge/src/main/java/io/github/techtastic/cc_vs/forge/mixin/MixinTileTurtle.java
+++ b/forge/src/main/java/io/github/techtastic/cc_vs/forge/mixin/MixinTileTurtle.java
@@ -31,7 +31,5 @@ public class MixinTileTurtle {
         ServerShip ship = VSGameUtilsKt.getShipObjectManagingPos(level, pos);
 
         CCVSUtils.INSTANCE.applyShipAPIsToComputer(computer, level, ship);
-
-        cir.setReturnValue(computer);
     }
 }


### PR DESCRIPTION
Tournament fix: https://github.com/alex-s168/VS_tournament_continued/pull/12

The mixins to computer craft turtles and computers should __not__ use `CallbackInfoReturnable#setReturnValue` because it also automatically cancels the processing of other mixins. Also doing this is useless anyways because the return value is already set.