### PR TITLE
1.20.x/feat/ship native

### DIFF
--- a/common/src/main/kotlin/io/github/techtastic/cc_vs/apis/ShipAPI.kt
+++ b/common/src/main/kotlin/io/github/techtastic/cc_vs/apis/ShipAPI.kt
@@ -6,6 +6,7 @@ import dan200.computercraft.api.lua.ILuaAPI
 import dan200.computercraft.api.lua.LuaException
 import dan200.computercraft.api.lua.LuaFunction
 import io.github.techtastic.cc_vs.mixin.ShipObjectWorldAccessor
+import io.github.techtastic.cc_vs.ship.PhysTickEventHandler
 import io.github.techtastic.cc_vs.util.CCVSUtils
 import io.github.techtastic.cc_vs.util.CCVSUtils.toLua
 import io.github.techtastic.cc_vs.util.CCVSUtils.toVector
@@ -78,6 +79,14 @@ open class ShipAPI(val system: IComputerSystem) : ILuaAPI {
             Pair("z", aabb.maxZ() - aabb.minZ())
         )
     }
+
+    @LuaFunction
+    fun getAcceleration(): Map<String, Double> =
+        PhysTickEventHandler.getOrCreateControl(getShip()).getAcceleration()
+
+    @LuaFunction
+    fun getRotationalAcceleration(): Map<String, Double> =
+        PhysTickEventHandler.getOrCreateControl(getShip()).getRotationalAcceleration()
 
     @LuaFunction
     fun getVelocity(): Map<String, Double> =

--- a/common/src/main/kotlin/io/github/techtastic/cc_vs/ship/PhysTickEventHandler.kt
+++ b/common/src/main/kotlin/io/github/techtastic/cc_vs/ship/PhysTickEventHandler.kt
@@ -3,24 +3,88 @@ package io.github.techtastic.cc_vs.ship
 import io.github.techtastic.cc_vs.PlatformUtils
 import io.github.techtastic.cc_vs.apis.LuaPhysShip
 import org.valkyrienskies.core.api.ships.*
+import org.joml.Vector3d
+import io.github.techtastic.cc_vs.util.CCVSUtils.toLua
 import org.valkyrienskies.core.impl.game.ships.PhysShipImpl
 import java.util.concurrent.ConcurrentLinkedQueue
+import com.fasterxml.jackson.annotation.JsonIgnore
 
-class PhysTickEventHandler: ShipForcesInducer {
+class PhysTickEventHandler : ShipForcesInducer {
+    @JsonIgnore
     private val queuedData = ConcurrentLinkedQueue<LuaPhysShip>()
 
+    // --- State ---
+    @JsonIgnore private var initialized = false
+    @JsonIgnore private val prevVel = Vector3d()
+    @JsonIgnore private val prevOmega = Vector3d()
+
+    // smoothed velocities (to suppress jitter)
+    @JsonIgnore private val smoothVel = Vector3d()
+    @JsonIgnore private val smoothOmega = Vector3d()
+
+    // filtered accelerations (final output)
+    @JsonIgnore private val smoothAcc = Vector3d()
+    @JsonIgnore private val smoothRotAcc = Vector3d()
+
+    // --- Filter constants ---
+    @JsonIgnore private val physDt = 1.0 / 60.0 // physics tick interval (s)
+
+    // velocity smoothing factor (0.3–0.5 typical)
+    @JsonIgnore private val beta = 0.5
+
+    // acceleration smoothing time constant and factor
+    @JsonIgnore private val tau = 0.1
+    @JsonIgnore private val alpha = physDt / (tau + physDt)
+
     override fun applyForces(physShip: PhysShip) {
+        val ship = physShip as PhysShipImpl
+        val vel = Vector3d(ship.poseVel.vel)
+        val omega = Vector3d(ship.poseVel.omega)
+
+        if (!initialized) {
+            // initialize smooth and previous values
+            prevVel.set(vel)
+            prevOmega.set(omega)
+            smoothVel.set(vel)
+            smoothOmega.set(omega)
+            initialized = true
+        }
+
+        // --- Step 1: Exponential smoothing on velocity (reduce jitter) ---
+        smoothVel.fma(beta, Vector3d(vel).sub(smoothVel), smoothVel)
+        smoothOmega.fma(beta, Vector3d(omega).sub(smoothOmega), smoothOmega)
+
+        // --- Step 2: Differentiate smoothed velocity ---
+        val rawAcc = Vector3d(smoothVel).sub(prevVel).div(physDt)
+        val rawRotAcc = Vector3d(smoothOmega).sub(prevOmega).div(physDt)
+
+        // --- Step 3: IIR low-pass on acceleration ---
+        smoothAcc.lerp(rawAcc, alpha)
+        smoothRotAcc.lerp(rawRotAcc, alpha)
+
+        // --- Update previous smoothed velocities ---
+        prevVel.set(smoothVel)
+        prevOmega.set(smoothOmega)
+
+
         if (!PlatformUtils.exposePhysTick())
             return
 
-        this.queuedData.add(LuaPhysShip(physShip as PhysShipImpl))
+        this.queuedData.add(LuaPhysShip(ship))
     }
 
+    @JsonIgnore
     fun getData(): Array<LuaPhysShip> {
         val data = this.queuedData.toTypedArray()
         this.queuedData.clear()
         return data
     }
+
+    @JsonIgnore
+    fun getAcceleration(): Map<String, Double> = smoothAcc.toLua()
+
+    @JsonIgnore
+    fun getRotationalAcceleration(): Map<String, Double> = smoothRotAcc.toLua()
 
     companion object {
         fun getOrCreateControl(ship: ServerShip): PhysTickEventHandler {


### PR DESCRIPTION
Add acceleration getters, derived from previous + current velocities and processed to produce a smoothed signal. 

Note: I also added back in the 'JsonIgnore', was this removed for a reason? Also had to mark all the getter functions with this, since I guess in Kotlin any function named 'getX' automatically creates a corresponding 'X' parameter, and thus is included in the serialization, which I think is unintended. 